### PR TITLE
feat(sdk): add convenience search methods to NfdClient

### DIFF
--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -173,7 +173,12 @@ export class NfdClient {
    * @throws If the mint operation fails
    */
   public async mint(nfdName: string, params: NfdMintParams): Promise<Nfd> {
-    return this._minting.mint(nfdName, params)
+    try {
+      return await this._minting.mint(nfdName, params)
+    } finally {
+      // Reset signer after operation
+      this._signer = null
+    }
   }
 
   /**

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -13,7 +13,12 @@ import {
   NfdMintQuoteParams,
 } from './modules/minting'
 
-import type { Nfd, ResolveOptions } from './types'
+import type {
+  Nfd,
+  ResolveOptions,
+  SearchOptions,
+  SearchResponse,
+} from './types'
 
 /**
  * Configuration options for the NFD client
@@ -168,11 +173,66 @@ export class NfdClient {
    * @throws If the mint operation fails
    */
   public async mint(nfdName: string, params: NfdMintParams): Promise<Nfd> {
-    try {
-      return await this._minting.mint(nfdName, params)
-    } finally {
-      // Reset signer after operation
-      this._signer = null
-    }
+    return this._minting.mint(nfdName, params)
+  }
+
+  /**
+   * Find the NFD associated with a specific wallet address
+   * @param address - The wallet address to look up
+   * @param options - Additional options for the lookup
+   * @returns The NFD associated with the address, or null if not found
+   */
+  public async resolveAddress(
+    address: string | Address,
+    options: {
+      view?: 'tiny' | 'thumbnail' | 'brief' | 'full'
+      allowUnverified?: boolean
+    } = {},
+  ): Promise<Nfd | null> {
+    const addressStr =
+      typeof address === 'string' ? address : address.toString()
+    const result = await this.api.reverseLookup([addressStr], options)
+    return result[addressStr] || null
+  }
+
+  /**
+   * Search for all NFDs owned by a specific wallet address
+   * @param address - The wallet address to search for
+   * @param options - Additional search options to apply
+   * @returns Search response containing owned NFDs
+   * @remarks
+   * By default, this method returns up to 20 results. You can override this by
+   * specifying a different limit in the options parameter.
+   */
+  public async searchByOwner(
+    address: string | Address,
+    options: Omit<SearchOptions, 'owner' | 'state'> = {},
+  ): Promise<SearchResponse> {
+    const addressStr =
+      typeof address === 'string' ? address : address.toString()
+    return this.api.search({
+      limit: 20,
+      ...options,
+      owner: addressStr,
+      state: ['owned'],
+    })
+  }
+
+  /**
+   * Search for all NFDs that are currently for sale
+   * @param options - Additional search options to apply
+   * @returns Search response containing NFDs for sale
+   * @remarks
+   * By default, this method returns up to 20 results. You can override this by
+   * specifying a different limit in the options parameter.
+   */
+  public async searchForSale(
+    options: Omit<SearchOptions, 'state'> = {},
+  ): Promise<SearchResponse> {
+    return this.api.search({
+      limit: 20,
+      ...options,
+      state: ['forSale'],
+    })
   }
 }


### PR DESCRIPTION
## Description

This PR adds convenience methods to the `NfdClient` class to simplify common NFD search operations. These methods make it easier for integrators to perform common queries without having to construct complex search parameters.

## Details
- Added `resolveAddress` method to find the NFD associated with a specific wallet address
- Added `searchByOwner` method to search for all NFDs owned by a specific wallet address
- Added `searchForSale` method to search for all NFDs that are currently for sale
- Set a reasonable default limit of 20 results for search methods
- Added clear documentation with `@remarks` tags explaining the default limits
- Ensured methods handle both string and `Address` object parameters consistently