### PR TITLE
feat(sdk): add optional reservedFor param to NFD minting

### DIFF
--- a/examples/mint/src/App.tsx
+++ b/examples/mint/src/App.tsx
@@ -13,6 +13,7 @@ const nfd = NfdClient.testNet()
 export function App() {
   const [nfdName, setNfdName] = useState('')
   const [years, setYears] = useState(1)
+  const [reservedFor, setReservedFor] = useState('')
   const [nfdData, setNfdData] = useState<Nfd | null>(null)
   const [quoteData, setQuoteData] = useState<NfdMintQuote | null>(null)
   const [error, setError] = useState('')
@@ -25,6 +26,12 @@ export function App() {
     setQuoteData(null)
     setNfdData(null)
     setNfdName(e.target.value)
+  }
+
+  const handleReservedForChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setQuoteData(null)
+    setNfdData(null)
+    setReservedFor(e.target.value)
   }
 
   const handleGetQuote = async (e: React.FormEvent) => {
@@ -78,6 +85,7 @@ export function App() {
         .mint(quote.nfdName, {
           buyer: quote.buyer,
           years: quote.years,
+          ...(reservedFor.trim() && { reservedFor: reservedFor.trim() }),
         })
 
       setNfdData(mintedNfd)
@@ -138,6 +146,20 @@ export function App() {
                     </option>
                   ))}
                 </select>
+              </div>
+
+              <div style={{ marginBottom: '10px' }}>
+                <label htmlFor="reservedFor" style={{ marginRight: '10px' }}>
+                  Reserved for (optional):
+                </label>
+                <input
+                  id="reservedFor"
+                  type="text"
+                  value={reservedFor}
+                  onChange={handleReservedForChange}
+                  placeholder="Enter Algorand address"
+                  style={{ width: '350px' }}
+                />
               </div>
             </fieldset>
 

--- a/packages/sdk/src/modules/minting.ts
+++ b/packages/sdk/src/modules/minting.ts
@@ -1,4 +1,5 @@
 import { AlgoAmount } from '@algorandfoundation/algokit-utils/types/amount'
+import { isValidAddress } from 'algosdk'
 
 import {
   canMintSegment,
@@ -25,6 +26,11 @@ export interface NfdMintParams {
    * Number of years until expiration (1-20)
    */
   years: number
+
+  /**
+   * Optional address to reserve the NFD for. If not provided, the buyer's address will be used.
+   */
+  reservedFor?: string
 }
 
 /**
@@ -264,7 +270,7 @@ export class MintingModule extends BaseModule {
       )
     }
 
-    const { buyer: buyerAddr, years: numYears } = params
+    const { buyer: buyerAddr, years: numYears, reservedFor } = params
 
     // Validate years parameter
     if (numYears <= 0) {
@@ -273,6 +279,11 @@ export class MintingModule extends BaseModule {
 
     if (!Number.isInteger(numYears)) {
       throw new Error('Years must be an integer')
+    }
+
+    // Validate reservedFor address
+    if (reservedFor && !isValidAddress(reservedFor)) {
+      throw new Error('Invalid reservedFor address')
     }
 
     // Get constraints to determine max years allowed
@@ -328,7 +339,7 @@ export class MintingModule extends BaseModule {
         args: {
           purchaseTxn: paymentTxn,
           nfdName,
-          reservedFor: buyerAddr,
+          reservedFor: reservedFor || buyerAddr,
           linkOnMint: false,
         },
         extraFee: AlgoAmount.MicroAlgos(extraFee),


### PR DESCRIPTION
## Description

This PR adds support for specifying a different `reservedFor` address when minting an NFD. This allows minting an NFD that will be owned by a different address than the buyer/signer of the transaction.

## Details
- Added optional `reservedFor` parameter to `NfdMintParams` interface in SDK
- Added validation of `reservedFor` address in SDK mint method
- Added input field to example app for specifying `reservedFor` address
- Updated minting logic in example app to pass `reservedFor` parameter when provided
- Maintained backward compatibility by keeping `reservedFor` optional