### PR TITLE
fix(lookup): parse reservedFor from on-chain state

### DIFF
--- a/packages/sdk/src/modules/lookup.ts
+++ b/packages/sdk/src/modules/lookup.ts
@@ -239,7 +239,7 @@ export class LookupModule extends BaseModule {
       expired: isExpired,
       owner: parseAddress('i.owner.a', globalState),
       nfdAccount: instanceClient.appAddress.toString(),
-      reservedFor: verified['reservedFor'],
+      reservedFor: parseAddress('i.reservedOwner.a', globalState) || undefined,
       sellAmount: parseUint64('i.sellamt', globalState),
       isMinting: parseString('i.minting', globalState) !== '',
     }
@@ -271,6 +271,9 @@ export class LookupModule extends BaseModule {
       }),
       seller: parseAddress('i.seller.a', globalState),
       nfdAccount: instanceClient.appAddress.toString(),
+      ...(parseAddress('i.reservedOwner.a', globalState) && {
+        reservedFor: parseAddress('i.reservedOwner.a', globalState),
+      }),
       metaTags,
       timeCreated: new Date(
         parseUint64('i.timeCreated', globalState) * 1000,
@@ -318,6 +321,9 @@ export class LookupModule extends BaseModule {
           name: parseString('i.name', globalState),
           owner: parseAddress('i.owner.a', globalState),
           seller: parseAddress('i.seller.a', globalState),
+          ...(parseAddress('i.reservedOwner.a', globalState) && {
+            reservedOwner: parseAddress('i.reservedOwner.a', globalState),
+          }),
           asaid: parseUint64('i.asaid', globalState).toString(),
           ...(globalState['i.parentAppID'] && {
             parentAppID: parseUint64('i.parentAppID', globalState).toString(),


### PR DESCRIPTION
## Description

This PR fixes reservation information extraction in the `resolve` method by reading from the actual on-chain state field `i.reservedOwner.a` instead of verified properties. This enables proper NFD claiming functionality for reserved NFDs.

## Details
- Changed `reservedFor` parsing from `verified['reservedFor']` to `parseAddress('i.reservedOwner.a', globalState)`
- Added top-level `reservedFor` property to NFD objects for consistent access
- Added `properties.internal.reservedOwner` property as alternative access path
- Fixed issue where reservation data was missing from resolve responses
- Enables proper validation of NFD claiming eligibility for reserved NFDs