### PR TITLE
fix(purchasing): update static fee for purchase transactions

### DIFF
--- a/packages/sdk/src/modules/purchasing.ts
+++ b/packages/sdk/src/modules/purchasing.ts
@@ -181,7 +181,7 @@ export class PurchasingModule extends BaseModule {
         .newGroup()
         .purchase({
           args: { payment: paymentTxn },
-          staticFee: AlgoAmount.MicroAlgos(4000), // 0.004 ALGO
+          staticFee: AlgoAmount.MicroAlgos(9000), // 0.009 ALGO
         })
         .send({ populateAppCallResources: true })
 
@@ -246,7 +246,7 @@ export class PurchasingModule extends BaseModule {
         .newGroup()
         .purchase({
           args: { payment: paymentTxn },
-          staticFee: AlgoAmount.MicroAlgos(4000), // 0.004 ALGO
+          staticFee: AlgoAmount.MicroAlgos(9000), // 0.009 ALGO
         })
         .send({ populateAppCallResources: true })
 

--- a/packages/sdk/tests/modules/purchasing.test.ts
+++ b/packages/sdk/tests/modules/purchasing.test.ts
@@ -293,7 +293,7 @@ describe('PurchasingModule', () => {
       expect(mockInstanceClient.newGroup().purchase).toHaveBeenCalledWith({
         args: { payment: { id: 'mock-txn' } },
         staticFee: expect.objectContaining({
-          amountInMicroAlgo: BigInt(4000),
+          amountInMicroAlgo: BigInt(9000),
         }),
       })
       expect(
@@ -360,7 +360,7 @@ describe('PurchasingModule', () => {
       expect(mockInstanceClient.newGroup().purchase).toHaveBeenCalledWith({
         args: { payment: { id: 'mock-txn' } },
         staticFee: expect.objectContaining({
-          amountInMicroAlgo: BigInt(4000),
+          amountInMicroAlgo: BigInt(9000),
         }),
       })
       expect(


### PR DESCRIPTION
## Description

This PR updates the static fee for NFD purchase transactions from 0.004 ALGO to 0.009 ALGO to ensure sufficient transaction fees for successful execution of claim and buy operations.

## Details
- Updated static fee in `claim` method from 4000 to 9000 microAlgos (0.004 to 0.009 ALGO)
- Updated static fee in `buy` method from 4000 to 9000 microAlgos (0.004 to 0.009 ALGO)
- Ensures adequate transaction fees for both purchase operations