### PR TITLE
ci: add example builds to workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,9 @@ jobs:
       - name: Build
         run: pnpm build
 
+      - name: Build Examples
+        run: pnpm build:examples
+
       - name: Publish
         run: |
           git config --global user.name 'Doug Richar'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -58,3 +58,6 @@ jobs:
 
       - name: Build
         run: pnpm build
+
+      - name: Build Examples
+        run: pnpm build:examples

--- a/examples/api-search/vite.config.ts
+++ b/examples/api-search/vite.config.ts
@@ -12,4 +12,14 @@ export default defineConfig({
       },
     }),
   ],
+  define: {
+    global: 'globalThis',
+  },
+  build: {
+    rollupOptions: {
+      // Workaround for vite-plugin-node-polyfills v0.24.0 + Vite 6 build issue
+      // See: https://github.com/davidmyersdev/vite-plugin-node-polyfills/issues/81
+      external: ['vite-plugin-node-polyfills/shims/buffer'],
+    },
+  },
 })

--- a/examples/claim-nfd/vite.config.ts
+++ b/examples/claim-nfd/vite.config.ts
@@ -12,4 +12,14 @@ export default defineConfig({
       },
     }),
   ],
+  define: {
+    global: 'globalThis',
+  },
+  build: {
+    rollupOptions: {
+      // Workaround for vite-plugin-node-polyfills v0.24.0 + Vite 6 build issue
+      // See: https://github.com/davidmyersdev/vite-plugin-node-polyfills/issues/81
+      external: ['vite-plugin-node-polyfills/shims/buffer'],
+    },
+  },
 })

--- a/examples/link-address/vite.config.ts
+++ b/examples/link-address/vite.config.ts
@@ -12,4 +12,14 @@ export default defineConfig({
       },
     }),
   ],
+  define: {
+    global: 'globalThis',
+  },
+  build: {
+    rollupOptions: {
+      // Workaround for vite-plugin-node-polyfills v0.24.0 + Vite 6 build issue
+      // See: https://github.com/davidmyersdev/vite-plugin-node-polyfills/issues/81
+      external: ['vite-plugin-node-polyfills/shims/buffer'],
+    },
+  },
 })

--- a/examples/mint/vite.config.ts
+++ b/examples/mint/vite.config.ts
@@ -12,4 +12,14 @@ export default defineConfig({
       },
     }),
   ],
+  define: {
+    global: 'globalThis',
+  },
+  build: {
+    rollupOptions: {
+      // Workaround for vite-plugin-node-polyfills v0.24.0 + Vite 6 build issue
+      // See: https://github.com/davidmyersdev/vite-plugin-node-polyfills/issues/81
+      external: ['vite-plugin-node-polyfills/shims/buffer'],
+    },
+  },
 })

--- a/examples/nfd-metadata/vite.config.ts
+++ b/examples/nfd-metadata/vite.config.ts
@@ -12,4 +12,14 @@ export default defineConfig({
       },
     }),
   ],
+  define: {
+    global: 'globalThis',
+  },
+  build: {
+    rollupOptions: {
+      // Workaround for vite-plugin-node-polyfills v0.24.0 + Vite 6 build issue
+      // See: https://github.com/davidmyersdev/vite-plugin-node-polyfills/issues/81
+      external: ['vite-plugin-node-polyfills/shims/buffer'],
+    },
+  },
 })

--- a/examples/resolve/vite.config.ts
+++ b/examples/resolve/vite.config.ts
@@ -12,4 +12,14 @@ export default defineConfig({
       },
     }),
   ],
+  define: {
+    global: 'globalThis',
+  },
+  build: {
+    rollupOptions: {
+      // Workaround for vite-plugin-node-polyfills v0.24.0 + Vite 6 build issue
+      // See: https://github.com/davidmyersdev/vite-plugin-node-polyfills/issues/81
+      external: ['vite-plugin-node-polyfills/shims/buffer'],
+    },
+  },
 })

--- a/examples/reverse-lookup/vite.config.ts
+++ b/examples/reverse-lookup/vite.config.ts
@@ -12,4 +12,14 @@ export default defineConfig({
       },
     }),
   ],
+  define: {
+    global: 'globalThis',
+  },
+  build: {
+    rollupOptions: {
+      // Workaround for vite-plugin-node-polyfills v0.24.0 + Vite 6 build issue
+      // See: https://github.com/davidmyersdev/vite-plugin-node-polyfills/issues/81
+      external: ['vite-plugin-node-polyfills/shims/buffer'],
+    },
+  },
 })

--- a/examples/set-metadata/vite.config.ts
+++ b/examples/set-metadata/vite.config.ts
@@ -12,4 +12,14 @@ export default defineConfig({
       },
     }),
   ],
+  define: {
+    global: 'globalThis',
+  },
+  build: {
+    rollupOptions: {
+      // Workaround for vite-plugin-node-polyfills v0.24.0 + Vite 6 build issue
+      // See: https://github.com/davidmyersdev/vite-plugin-node-polyfills/issues/81
+      external: ['vite-plugin-node-polyfills/shims/buffer'],
+    },
+  },
 })

--- a/examples/set-primary-nfd/vite.config.ts
+++ b/examples/set-primary-nfd/vite.config.ts
@@ -12,4 +12,14 @@ export default defineConfig({
       },
     }),
   ],
+  define: {
+    global: 'globalThis',
+  },
+  build: {
+    rollupOptions: {
+      // Workaround for vite-plugin-node-polyfills v0.24.0 + Vite 6 build issue
+      // See: https://github.com/davidmyersdev/vite-plugin-node-polyfills/issues/81
+      external: ['vite-plugin-node-polyfills/shims/buffer'],
+    },
+  },
 })

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "pnpm --filter @txnlab/nfd-sdk build",
-    "build:examples": "pnpm --filter @txnlab/nfd-sdk-examples build",
+    "build:examples": "pnpm --filter './examples/*' build",
     "test": "pnpm -r test",
     "lint": "pnpm -r lint",
     "format": "pnpm -r format",


### PR DESCRIPTION
## Summary

This PR adds build validation for example projects to the CI/PR workflows and fixes build errors that were preventing production builds.

## Changes

- **Vite Configuration**: Added build configuration to all example projects to fix production build errors with `vite-plugin-node-polyfills` v0.24.0 + Vite 6
  - Added `global: 'globalThis'` polyfill definition
  - Added `rollupOptions` to exclude `vite-plugin-node-polyfills` buffer shim
- **CI/PR Workflows**: Added 'Build Examples' step to validate example builds
  - Added to PR workflow at the end
  - Added to CI workflow before publish step
- **Root Package Script**: Fixed `build:examples` script to use correct filter pattern

## Test Plan

- [x] Verify all example projects build successfully locally
- [x] Verify PR workflow runs successfully with example builds
- [x] Verify CI workflow runs successfully with example builds
