### PR TITLE
chore(deps)!: make algosdk a peer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,15 +28,17 @@ Once we reach v1.0.0 with all planned features, breaking changes will only be in
 
 ## Installation
 
+The SDK requires `algosdk` as a peer dependency. Install both packages:
+
 ```bash
 # npm
-npm install @txnlab/nfd-sdk
+npm install @txnlab/nfd-sdk algosdk
 
 # yarn
-yarn add @txnlab/nfd-sdk
+yarn add @txnlab/nfd-sdk algosdk
 
 # pnpm
-pnpm add @txnlab/nfd-sdk
+pnpm add @txnlab/nfd-sdk algosdk
 ```
 
 ## Quick Start

--- a/examples/api-search/package.json
+++ b/examples/api-search/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@txnlab/nfd-sdk": "^0.10.1",
+    "algosdk": "^3.5.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/examples/claim-nfd/package.json
+++ b/examples/claim-nfd/package.json
@@ -12,7 +12,7 @@
     "@algorandfoundation/algokit-utils": "^8.2.2",
     "@txnlab/nfd-sdk": "^0.10.1",
     "@txnlab/use-wallet-react": "^4.0.0",
-    "algosdk": "^3.2.0",
+    "algosdk": "^3.5.2",
     "lute-connect": "^1.4.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/examples/link-address/package.json
+++ b/examples/link-address/package.json
@@ -12,7 +12,7 @@
     "@algorandfoundation/algokit-utils": "^8.2.2",
     "@txnlab/nfd-sdk": "^0.10.1",
     "@txnlab/use-wallet-react": "^4.0.0",
-    "algosdk": "^3.2.0",
+    "algosdk": "^3.5.2",
     "lute-connect": "^1.4.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/examples/mint/package.json
+++ b/examples/mint/package.json
@@ -12,7 +12,7 @@
     "@algorandfoundation/algokit-utils": "^8.2.2",
     "@txnlab/nfd-sdk": "^0.10.1",
     "@txnlab/use-wallet-react": "^4.0.0",
-    "algosdk": "^3.2.0",
+    "algosdk": "^3.5.2",
     "lute-connect": "^1.4.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/examples/nfd-metadata/package.json
+++ b/examples/nfd-metadata/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@txnlab/nfd-sdk": "^0.10.1",
+    "algosdk": "^3.5.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/examples/resolve/package.json
+++ b/examples/resolve/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@txnlab/nfd-sdk": "^0.10.1",
+    "algosdk": "^3.5.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/examples/reverse-lookup/package.json
+++ b/examples/reverse-lookup/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@txnlab/nfd-sdk": "^0.10.1",
+    "algosdk": "^3.5.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/examples/set-metadata/package.json
+++ b/examples/set-metadata/package.json
@@ -12,7 +12,7 @@
     "@algorandfoundation/algokit-utils": "^8.2.2",
     "@txnlab/nfd-sdk": "^0.10.1",
     "@txnlab/use-wallet-react": "^4.0.0",
-    "algosdk": "^3.2.0",
+    "algosdk": "^3.5.2",
     "lute-connect": "^1.4.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/examples/set-primary-nfd/package.json
+++ b/examples/set-primary-nfd/package.json
@@ -12,7 +12,7 @@
     "@algorandfoundation/algokit-utils": "^8.2.2",
     "@txnlab/nfd-sdk": "^0.10.1",
     "@txnlab/use-wallet-react": "^4.0.0",
-    "algosdk": "^3.2.0",
+    "algosdk": "^3.5.2",
     "lute-connect": "^1.4.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -2,41 +2,19 @@
 
 SDK for interacting with NFDomains (NFD) API and Algorand blockchain. This package provides methods for domain resolution, record fetching, minting, and address linking operations.
 
-## Versioning
-
-This SDK is in early development (pre-1.0.0) and may introduce breaking changes despite our best efforts to avoid them. We recommend pinning the version in your package.json:
-
-```json
-{
-  "dependencies": {
-    "@txnlab/nfd-sdk": "0.1.2"
-  }
-}
-```
-
-Instead of using caret versioning:
-
-```json
-{
-  "dependencies": {
-    "@txnlab/nfd-sdk": "^0.1.2"
-  }
-}
-```
-
-Once we reach v1.0.0 with all planned features, breaking changes will only be introduced via major version bumps following semantic versioning.
-
 ## Installation
+
+The SDK requires `algosdk` as a peer dependency. Install both packages:
 
 ```bash
 # npm
-npm install @txnlab/nfd-sdk
+npm install @txnlab/nfd-sdk algosdk
 
 # yarn
-yarn add @txnlab/nfd-sdk
+yarn add @txnlab/nfd-sdk algosdk
 
 # pnpm
-pnpm add @txnlab/nfd-sdk
+pnpm add @txnlab/nfd-sdk algosdk
 ```
 
 ## Quick Start

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -68,8 +68,10 @@
   "dependencies": {
     "@algorandfoundation/algokit-utils": "^8.2.2",
     "@hey-api/client-fetch": "^0.8.1",
-    "algosdk": "^3.2.0",
     "crypto-js": "^4.2.0"
+  },
+  "peerDependencies": {
+    "algosdk": "^3.0.0"
   },
   "devDependencies": {
     "@algorandfoundation/algokit-client-generator": "^4.0.8",
@@ -80,6 +82,7 @@
     "@types/node-fetch": "^2.6.12",
     "@vitest/coverage-v8": "^3.0.7",
     "@vitest/ui": "^3.0.7",
+    "algosdk": "^3.5.2",
     "dotenv": "^16.4.7",
     "node-fetch": "^3.3.2",
     "publint": "^0.3.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -373,20 +373,17 @@ importers:
     dependencies:
       '@algorandfoundation/algokit-utils':
         specifier: ^8.2.2
-        version: 8.2.2(algosdk@3.2.0)
+        version: 8.2.2(algosdk@3.5.2)
       '@hey-api/client-fetch':
         specifier: ^0.8.1
         version: 0.8.1
-      algosdk:
-        specifier: ^3.2.0
-        version: 3.2.0
       crypto-js:
         specifier: ^4.2.0
         version: 4.2.0
     devDependencies:
       '@algorandfoundation/algokit-client-generator':
         specifier: ^4.0.8
-        version: 4.0.8(@algorandfoundation/algokit-utils@8.2.2(algosdk@3.2.0))(algosdk@3.2.0)
+        version: 4.0.8(@algorandfoundation/algokit-utils@8.2.2(algosdk@3.5.2))(algosdk@3.5.2)
       '@hey-api/openapi-ts':
         specifier: ^0.64.5
         version: 0.64.5(magicast@0.3.5)(typescript@5.7.3)
@@ -408,6 +405,9 @@ importers:
       '@vitest/ui':
         specifier: ^3.0.7
         version: 3.0.7(vitest@3.0.7)
+      algosdk:
+        specifier: ^3.5.2
+        version: 3.5.2
       dotenv:
         specifier: ^16.4.7
         version: 16.4.7
@@ -1453,6 +1453,10 @@ packages:
 
   algosdk@3.2.0:
     resolution: {integrity: sha512-iz7cRtv03vuYgQYp2IfLs+n512dxdjpalALZNiiFvreM7/oPmflfLkfD5dph/HUQwuJTomXx51LgiY19QP5ihg==}
+    engines: {node: '>=18.0.0'}
+
+  algosdk@3.5.2:
+    resolution: {integrity: sha512-frhGtZl1JvfrLRKmMvUm880wj4OiWsWo2FhbreNWh7pdFsKuWPj60fV682wt/CYefLI70iwHavPOwGBkTVt0VA==}
     engines: {node: '>=18.0.0'}
 
   alien-signals@0.4.14:
@@ -2832,6 +2836,7 @@ packages:
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
 
   node-fetch-native@1.6.6:
     resolution: {integrity: sha512-8Mc2HhqPdlIfedsuZoc3yioPuzp6b+L5jRCRY1QzuWZh2EGJVQrGppC6V6cF0bLdbW0+O2YpqCA25aF/1lvipQ==}
@@ -3830,10 +3835,10 @@ packages:
 
 snapshots:
 
-  '@algorandfoundation/algokit-client-generator@4.0.8(@algorandfoundation/algokit-utils@8.2.2(algosdk@3.2.0))(algosdk@3.2.0)':
+  '@algorandfoundation/algokit-client-generator@4.0.8(@algorandfoundation/algokit-utils@8.2.2(algosdk@3.5.2))(algosdk@3.5.2)':
     dependencies:
-      '@algorandfoundation/algokit-utils': 8.2.2(algosdk@3.2.0)
-      algosdk: 3.2.0
+      '@algorandfoundation/algokit-utils': 8.2.2(algosdk@3.5.2)
+      algosdk: 3.5.2
       chalk: 4.1.2
       change-case: 5.4.4
       commander: 11.1.0
@@ -3842,6 +3847,11 @@ snapshots:
   '@algorandfoundation/algokit-utils@8.2.2(algosdk@3.2.0)':
     dependencies:
       algosdk: 3.2.0
+      buffer: 6.0.3
+
+  '@algorandfoundation/algokit-utils@8.2.2(algosdk@3.5.2)':
+    dependencies:
+      algosdk: 3.5.2
       buffer: 6.0.3
 
   '@ampproject/remapping@2.3.0':
@@ -4850,6 +4860,17 @@ snapshots:
   algorand-msgpack@1.1.0: {}
 
   algosdk@3.2.0:
+    dependencies:
+      algorand-msgpack: 1.1.0
+      hi-base32: 0.5.1
+      js-sha256: 0.9.0
+      js-sha3: 0.8.0
+      js-sha512: 0.8.0
+      json-bigint: 1.0.0
+      tweetnacl: 1.0.3
+      vlq: 2.0.4
+
+  algosdk@3.5.2:
     dependencies:
       algorand-msgpack: 1.1.0
       hi-base32: 0.5.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       '@txnlab/nfd-sdk':
         specifier: workspace:*
         version: link:../../packages/sdk
+      algosdk:
+        specifier: ^3.5.2
+        version: 3.5.2
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -89,16 +92,16 @@ importers:
     dependencies:
       '@algorandfoundation/algokit-utils':
         specifier: ^8.2.2
-        version: 8.2.2(algosdk@3.2.0)
+        version: 8.2.2(algosdk@3.5.2)
       '@txnlab/nfd-sdk':
         specifier: workspace:*
         version: link:../../packages/sdk
       '@txnlab/use-wallet-react':
         specifier: ^4.0.0
-        version: 4.0.0(algosdk@3.2.0)(lute-connect@1.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 4.0.0(algosdk@3.5.2)(lute-connect@1.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       algosdk:
-        specifier: ^3.2.0
-        version: 3.2.0
+        specifier: ^3.5.2
+        version: 3.5.2
       lute-connect:
         specifier: ^1.4.1
         version: 1.4.1
@@ -129,16 +132,16 @@ importers:
     dependencies:
       '@algorandfoundation/algokit-utils':
         specifier: ^8.2.2
-        version: 8.2.2(algosdk@3.2.0)
+        version: 8.2.2(algosdk@3.5.2)
       '@txnlab/nfd-sdk':
         specifier: workspace:*
         version: link:../../packages/sdk
       '@txnlab/use-wallet-react':
         specifier: ^4.0.0
-        version: 4.0.0(algosdk@3.2.0)(lute-connect@1.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 4.0.0(algosdk@3.5.2)(lute-connect@1.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       algosdk:
-        specifier: ^3.2.0
-        version: 3.2.0
+        specifier: ^3.5.2
+        version: 3.5.2
       lute-connect:
         specifier: ^1.4.1
         version: 1.4.1
@@ -169,16 +172,16 @@ importers:
     dependencies:
       '@algorandfoundation/algokit-utils':
         specifier: ^8.2.2
-        version: 8.2.2(algosdk@3.2.0)
+        version: 8.2.2(algosdk@3.5.2)
       '@txnlab/nfd-sdk':
         specifier: workspace:*
         version: link:../../packages/sdk
       '@txnlab/use-wallet-react':
         specifier: ^4.0.0
-        version: 4.0.0(algosdk@3.2.0)(lute-connect@1.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 4.0.0(algosdk@3.5.2)(lute-connect@1.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       algosdk:
-        specifier: ^3.2.0
-        version: 3.2.0
+        specifier: ^3.5.2
+        version: 3.5.2
       lute-connect:
         specifier: ^1.4.1
         version: 1.4.1
@@ -210,6 +213,9 @@ importers:
       '@txnlab/nfd-sdk':
         specifier: workspace:*
         version: link:../../packages/sdk
+      algosdk:
+        specifier: ^3.5.2
+        version: 3.5.2
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -238,6 +244,9 @@ importers:
       '@txnlab/nfd-sdk':
         specifier: workspace:*
         version: link:../../packages/sdk
+      algosdk:
+        specifier: ^3.5.2
+        version: 3.5.2
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -266,6 +275,9 @@ importers:
       '@txnlab/nfd-sdk':
         specifier: workspace:*
         version: link:../../packages/sdk
+      algosdk:
+        specifier: ^3.5.2
+        version: 3.5.2
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -293,16 +305,16 @@ importers:
     dependencies:
       '@algorandfoundation/algokit-utils':
         specifier: ^8.2.2
-        version: 8.2.2(algosdk@3.2.0)
+        version: 8.2.2(algosdk@3.5.2)
       '@txnlab/nfd-sdk':
         specifier: workspace:*
         version: link:../../packages/sdk
       '@txnlab/use-wallet-react':
         specifier: ^4.0.0
-        version: 4.0.0(algosdk@3.2.0)(lute-connect@1.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 4.0.0(algosdk@3.5.2)(lute-connect@1.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       algosdk:
-        specifier: ^3.2.0
-        version: 3.2.0
+        specifier: ^3.5.2
+        version: 3.5.2
       lute-connect:
         specifier: ^1.4.1
         version: 1.4.1
@@ -333,16 +345,16 @@ importers:
     dependencies:
       '@algorandfoundation/algokit-utils':
         specifier: ^8.2.2
-        version: 8.2.2(algosdk@3.2.0)
+        version: 8.2.2(algosdk@3.5.2)
       '@txnlab/nfd-sdk':
         specifier: workspace:*
         version: link:../../packages/sdk
       '@txnlab/use-wallet-react':
         specifier: ^4.0.0
-        version: 4.0.0(algosdk@3.2.0)(lute-connect@1.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 4.0.0(algosdk@3.5.2)(lute-connect@1.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       algosdk:
-        specifier: ^3.2.0
-        version: 3.2.0
+        specifier: ^3.5.2
+        version: 3.5.2
       lute-connect:
         specifier: ^1.4.1
         version: 1.4.1
@@ -386,10 +398,10 @@ importers:
         version: 4.0.8(@algorandfoundation/algokit-utils@8.2.2(algosdk@3.5.2))(algosdk@3.5.2)
       '@hey-api/openapi-ts':
         specifier: ^0.64.5
-        version: 0.64.5(magicast@0.3.5)(typescript@5.7.3)
+        version: 0.64.5(magicast@0.3.5)(typescript@5.9.3)
       '@tanstack/config':
         specifier: ^0.16.2
-        version: 0.16.3(@types/node@22.13.9)(esbuild@0.25.0)(eslint@9.21.0(jiti@2.4.2))(rollup@4.34.8)(typescript@5.7.3)(vite@6.2.0(@types/node@22.13.9)(jiti@2.4.2)(tsx@4.19.3)(yaml@2.7.0))
+        version: 0.16.3(@types/node@22.13.9)(esbuild@0.25.0)(eslint@9.39.0(jiti@2.4.2))(rollup@4.34.8)(typescript@5.9.3)(vite@6.2.0(@types/node@22.13.9)(jiti@2.4.2)(tsx@4.19.3)(yaml@2.7.0))
       '@types/crypto-js':
         specifier: ^4.2.2
         version: 4.2.2
@@ -428,10 +440,10 @@ importers:
         version: 6.2.0(@types/node@22.13.9)(jiti@2.4.2)(tsx@4.19.3)(yaml@2.7.0)
       vite-plugin-dts:
         specifier: ^4.5.0
-        version: 4.5.0(@types/node@22.13.9)(rollup@4.34.8)(typescript@5.7.3)(vite@6.2.0(@types/node@22.13.9)(jiti@2.4.2)(tsx@4.19.3)(yaml@2.7.0))
+        version: 4.5.0(@types/node@22.13.9)(rollup@4.34.8)(typescript@5.9.3)(vite@6.2.0(@types/node@22.13.9)(jiti@2.4.2)(tsx@4.19.3)(yaml@2.7.0))
       vite-tsconfig-paths:
         specifier: ^5.1.4
-        version: 5.1.4(typescript@5.7.3)(vite@6.2.0(@types/node@22.13.9)(jiti@2.4.2)(tsx@4.19.3)(yaml@2.7.0))
+        version: 5.1.4(typescript@5.9.3)(vite@6.2.0(@types/node@22.13.9)(jiti@2.4.2)(tsx@4.19.3)(yaml@2.7.0))
       vitest:
         specifier: ^3.0.7
         version: 3.0.7(@types/node@22.13.9)(@vitest/ui@3.0.7)(jiti@2.4.2)(tsx@4.19.3)(yaml@2.7.0)
@@ -835,32 +847,70 @@ packages:
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
 
+  '@eslint-community/eslint-utils@4.9.0':
+    resolution: {integrity: sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
   '@eslint-community/regexpp@4.12.1':
     resolution: {integrity: sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
   '@eslint/config-array@0.19.2':
     resolution: {integrity: sha512-GNKqxfHG2ySmJOBSHg7LxeUx4xpuCoFjacmlCoYWEbaPXLwvfIjixRI12xCQZeULksQb23uiA8F40w5TojpV7w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@eslint/config-array@0.21.1':
+    resolution: {integrity: sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/config-helpers@0.4.2':
+    resolution: {integrity: sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@eslint/core@0.12.0':
     resolution: {integrity: sha512-cmrR6pytBuSMTaBweKoGMwu3EiHiEC+DoyupPmlZ0HxBJBtIxwe+j/E4XPIKNx+Q74c8lXKPwYawBf5glsTkHg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/core@0.17.0':
+    resolution: {integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/eslintrc@3.3.0':
     resolution: {integrity: sha512-yaVPAiNAalnCZedKLdR21GOGILMLKPyqSLWaAjQFvYA2i/ciDi8ArYVr69Anohb6cH2Ukhqti4aFnYyPm8wdwQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@eslint/eslintrc@3.3.1':
+    resolution: {integrity: sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@eslint/js@9.21.0':
     resolution: {integrity: sha512-BqStZ3HX8Yz6LvsF5ByXYrtigrV5AXADWLAGc7PH/1SxOb7/FIYYMszZZWiUou/GB9P2lXWk2SV4d+Z8h0nknw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/js@9.39.0':
+    resolution: {integrity: sha512-BIhe0sW91JGPiaF1mOuPy5v8NflqfjIcDNpC+LbW9f609WVRX1rArrhi6Z2ymvrAry9jw+5POTj4t2t62o8Bmw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/object-schema@2.1.6':
     resolution: {integrity: sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@eslint/object-schema@2.1.7':
+    resolution: {integrity: sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@eslint/plugin-kit@0.2.7':
     resolution: {integrity: sha512-JubJ5B2pJ4k4yGxaNLdbjrnk9d/iDz6/q8wOilpIowd6PJPgaxCuHBnBszq7Ce2TyMrywm5r4PnKm6V3iiZF+g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/plugin-kit@0.4.1':
+    resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@gerrit0/mini-shiki@1.27.2':
@@ -889,6 +939,10 @@ packages:
     resolution: {integrity: sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==}
     engines: {node: '>=18.18.0'}
 
+  '@humanfs/node@0.16.7':
+    resolution: {integrity: sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==}
+    engines: {node: '>=18.18.0'}
+
   '@humanwhocodes/module-importer@1.0.1':
     resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
     engines: {node: '>=12.22'}
@@ -899,6 +953,10 @@ packages:
 
   '@humanwhocodes/retry@0.4.2':
     resolution: {integrity: sha512-xeO57FpIu4p1Ri3Jq/EXq4ClRm86dVF2z/+kvFnyqVYRavTZmaFaUBbWCOuuTh0o/g7DSsk6kc2vrS4Vl5oPOQ==}
+    engines: {node: '>=18.18'}
+
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
   '@isaacs/cliui@8.0.2':
@@ -1246,6 +1304,9 @@ packages:
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
 
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
@@ -1422,6 +1483,11 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  acorn@8.15.0:
+    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
   ajv-draft-04@1.0.0:
     resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
     peerDependencies:
@@ -1450,10 +1516,6 @@ packages:
   algorand-msgpack@1.1.0:
     resolution: {integrity: sha512-08k7pBQnkaUB5p+jL7f1TRaUIlTSDE0cesFu1mD7llLao+1cAhtvvZmGE3OnisTd0xOn118QMw74SRqddqaYvw==}
     engines: {node: '>= 14'}
-
-  algosdk@3.2.0:
-    resolution: {integrity: sha512-iz7cRtv03vuYgQYp2IfLs+n512dxdjpalALZNiiFvreM7/oPmflfLkfD5dph/HUQwuJTomXx51LgiY19QP5ihg==}
-    engines: {node: '>=18.0.0'}
 
   algosdk@3.5.2:
     resolution: {integrity: sha512-frhGtZl1JvfrLRKmMvUm880wj4OiWsWo2FhbreNWh7pdFsKuWPj60fV682wt/CYefLI70iwHavPOwGBkTVt0VA==}
@@ -1550,8 +1612,8 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  bignumber.js@9.1.2:
-    resolution: {integrity: sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==}
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
   bn.js@4.12.1:
     resolution: {integrity: sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==}
@@ -1817,6 +1879,15 @@ packages:
       supports-color:
         optional: true
 
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
@@ -2039,12 +2110,20 @@ packages:
     resolution: {integrity: sha512-PHlWUfG6lvPc3yvP5A4PNyBL1W8fkDUccmI21JUu/+GKZBoH/W5u6usENXUrWFRsyoW5ACUjFGgAFQp5gUlb/A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  eslint-scope@8.4.0:
+    resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   eslint-visitor-keys@3.4.3:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   eslint-visitor-keys@4.2.0:
     resolution: {integrity: sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-visitor-keys@4.2.1:
+    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   eslint@9.21.0:
@@ -2057,8 +2136,22 @@ packages:
       jiti:
         optional: true
 
+  eslint@9.39.0:
+    resolution: {integrity: sha512-iy2GE3MHrYTL5lrCtMZ0X1KLEKKUjmK0kzwcnefhR66txcEmXZD2YWgR5GNdcEwkNx3a0siYkSvl0vIC+Svjmg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
   espree@10.3.0:
     resolution: {integrity: sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  espree@10.4.0:
+    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   espree@9.6.1:
@@ -3547,6 +3640,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   uc.micro@2.1.0:
     resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
@@ -3844,11 +3942,6 @@ snapshots:
       commander: 11.1.0
       jsonschema: 1.5.0
 
-  '@algorandfoundation/algokit-utils@8.2.2(algosdk@3.2.0)':
-    dependencies:
-      algosdk: 3.2.0
-      buffer: 6.0.3
-
   '@algorandfoundation/algokit-utils@8.2.2(algosdk@3.5.2)':
     dependencies:
       algosdk: 3.5.2
@@ -4128,7 +4221,19 @@ snapshots:
       eslint: 9.21.0(jiti@2.4.2)
       eslint-visitor-keys: 3.4.3
 
+  '@eslint-community/eslint-utils@4.4.1(eslint@9.39.0(jiti@2.4.2))':
+    dependencies:
+      eslint: 9.39.0(jiti@2.4.2)
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/eslint-utils@4.9.0(eslint@9.39.0(jiti@2.4.2))':
+    dependencies:
+      eslint: 9.39.0(jiti@2.4.2)
+      eslint-visitor-keys: 3.4.3
+
   '@eslint-community/regexpp@4.12.1': {}
+
+  '@eslint-community/regexpp@4.12.2': {}
 
   '@eslint/config-array@0.19.2':
     dependencies:
@@ -4138,7 +4243,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@eslint/config-array@0.21.1':
+    dependencies:
+      '@eslint/object-schema': 2.1.7
+      debug: 4.4.3
+      minimatch: 3.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/config-helpers@0.4.2':
+    dependencies:
+      '@eslint/core': 0.17.0
+
   '@eslint/core@0.12.0':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/core@0.17.0':
     dependencies:
       '@types/json-schema': 7.0.15
 
@@ -4156,13 +4277,36 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@eslint/eslintrc@3.3.1':
+    dependencies:
+      ajv: 6.12.6
+      debug: 4.4.3
+      espree: 10.4.0
+      globals: 14.0.0
+      ignore: 5.3.2
+      import-fresh: 3.3.1
+      js-yaml: 4.1.0
+      minimatch: 3.1.2
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@eslint/js@9.21.0': {}
 
+  '@eslint/js@9.39.0': {}
+
   '@eslint/object-schema@2.1.6': {}
+
+  '@eslint/object-schema@2.1.7': {}
 
   '@eslint/plugin-kit@0.2.7':
     dependencies:
       '@eslint/core': 0.12.0
+      levn: 0.4.1
+
+  '@eslint/plugin-kit@0.4.1':
+    dependencies:
+      '@eslint/core': 0.17.0
       levn: 0.4.1
 
   '@gerrit0/mini-shiki@1.27.2':
@@ -4179,13 +4323,13 @@ snapshots:
       '@types/json-schema': 7.0.15
       js-yaml: 4.1.0
 
-  '@hey-api/openapi-ts@0.64.5(magicast@0.3.5)(typescript@5.7.3)':
+  '@hey-api/openapi-ts@0.64.5(magicast@0.3.5)(typescript@5.9.3)':
     dependencies:
       '@hey-api/json-schema-ref-parser': 1.0.2
       c12: 2.0.1(magicast@0.3.5)
       commander: 13.0.0
       handlebars: 4.7.8
-      typescript: 5.7.3
+      typescript: 5.9.3
     transitivePeerDependencies:
       - magicast
 
@@ -4196,11 +4340,18 @@ snapshots:
       '@humanfs/core': 0.19.1
       '@humanwhocodes/retry': 0.3.1
 
+  '@humanfs/node@0.16.7':
+    dependencies:
+      '@humanfs/core': 0.19.1
+      '@humanwhocodes/retry': 0.4.3
+
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/retry@0.3.1': {}
 
   '@humanwhocodes/retry@0.4.2': {}
+
+  '@humanwhocodes/retry@0.4.3': {}
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -4476,6 +4627,12 @@ snapshots:
       eslint-visitor-keys: 4.2.0
       espree: 10.3.0
 
+  '@stylistic/eslint-plugin-js@4.0.1(eslint@9.39.0(jiti@2.4.2))':
+    dependencies:
+      eslint: 9.39.0(jiti@2.4.2)
+      eslint-visitor-keys: 4.2.0
+      espree: 10.3.0
+
   '@tanstack/config@0.16.3(@types/node@22.13.9)(esbuild@0.25.0)(eslint@9.21.0(jiti@2.4.2))(rollup@4.34.8)(typescript@5.7.3)(vite@6.2.0(@types/node@22.13.9)(jiti@2.4.2)(tsx@4.19.3)(yaml@2.7.0))':
     dependencies:
       '@commitlint/parse': 19.5.0
@@ -4511,6 +4668,41 @@ snapshots:
       - typescript
       - vite
 
+  '@tanstack/config@0.16.3(@types/node@22.13.9)(esbuild@0.25.0)(eslint@9.39.0(jiti@2.4.2))(rollup@4.34.8)(typescript@5.9.3)(vite@6.2.0(@types/node@22.13.9)(jiti@2.4.2)(tsx@4.19.3)(yaml@2.7.0))':
+    dependencies:
+      '@commitlint/parse': 19.5.0
+      '@eslint/js': 9.21.0
+      '@stylistic/eslint-plugin-js': 4.0.1(eslint@9.39.0(jiti@2.4.2))
+      commander: 13.1.0
+      esbuild-register: 3.6.0(esbuild@0.25.0)
+      eslint-plugin-import-x: 4.6.1(eslint@9.39.0(jiti@2.4.2))(typescript@5.9.3)
+      eslint-plugin-n: 17.15.1(eslint@9.39.0(jiti@2.4.2))
+      globals: 16.0.0
+      interpret: 3.1.1
+      jsonfile: 6.1.0
+      liftoff: 5.0.0
+      minimist: 1.2.8
+      rollup-plugin-preserve-directives: 0.4.0(rollup@4.34.8)
+      semver: 7.7.1
+      simple-git: 3.27.0
+      typedoc: 0.27.9(typescript@5.9.3)
+      typedoc-plugin-frontmatter: 1.2.1(typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.7.3)))
+      typedoc-plugin-markdown: 4.4.2(typedoc@0.27.9(typescript@5.7.3))
+      typescript-eslint: 8.25.0(eslint@9.39.0(jiti@2.4.2))(typescript@5.9.3)
+      v8flags: 4.0.1
+      vite-plugin-dts: 4.2.3(@types/node@22.13.9)(rollup@4.34.8)(typescript@5.9.3)(vite@6.2.0(@types/node@22.13.9)(jiti@2.4.2)(tsx@4.19.3)(yaml@2.7.0))
+      vite-plugin-externalize-deps: 0.9.0(vite@6.2.0(@types/node@22.13.9)(jiti@2.4.2)(tsx@4.19.3)(yaml@2.7.0))
+      vite-tsconfig-paths: 5.1.4(typescript@5.9.3)(vite@6.2.0(@types/node@22.13.9)(jiti@2.4.2)(tsx@4.19.3)(yaml@2.7.0))
+      vue-eslint-parser: 9.4.3(eslint@9.39.0(jiti@2.4.2))
+    transitivePeerDependencies:
+      - '@types/node'
+      - esbuild
+      - eslint
+      - rollup
+      - supports-color
+      - typescript
+      - vite
+
   '@tanstack/react-store@0.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@tanstack/store': 0.7.0
@@ -4520,11 +4712,11 @@ snapshots:
 
   '@tanstack/store@0.7.0': {}
 
-  '@txnlab/use-wallet-react@4.0.0(algosdk@3.2.0)(lute-connect@1.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@txnlab/use-wallet-react@4.0.0(algosdk@3.5.2)(lute-connect@1.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@tanstack/react-store': 0.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@txnlab/use-wallet': 4.0.0(algosdk@3.2.0)(lute-connect@1.4.1)
-      algosdk: 3.2.0
+      '@txnlab/use-wallet': 4.0.0(algosdk@3.5.2)(lute-connect@1.4.1)
+      algosdk: 3.5.2
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
@@ -4532,10 +4724,10 @@ snapshots:
     transitivePeerDependencies:
       - '@agoralabs-sh/avm-web-provider'
 
-  '@txnlab/use-wallet@4.0.0(algosdk@3.2.0)(lute-connect@1.4.1)':
+  '@txnlab/use-wallet@4.0.0(algosdk@3.5.2)(lute-connect@1.4.1)':
     dependencies:
       '@tanstack/store': 0.7.0
-      algosdk: 3.2.0
+      algosdk: 3.5.2
     optionalDependencies:
       lute-connect: 1.4.1
 
@@ -4571,6 +4763,8 @@ snapshots:
   '@types/doctrine@0.0.9': {}
 
   '@types/estree@1.0.6': {}
+
+  '@types/estree@1.0.8': {}
 
   '@types/hast@3.0.4':
     dependencies:
@@ -4619,6 +4813,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/eslint-plugin@8.25.0(@typescript-eslint/parser@8.25.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.39.0(jiti@2.4.2))(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.1
+      '@typescript-eslint/parser': 8.25.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
+      '@typescript-eslint/scope-manager': 8.25.0
+      '@typescript-eslint/type-utils': 8.25.0(eslint@9.39.0(jiti@2.4.2))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.25.0(eslint@9.39.0(jiti@2.4.2))(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.25.0
+      eslint: 9.39.0(jiti@2.4.2)
+      graphemer: 1.4.0
+      ignore: 5.3.2
+      natural-compare: 1.4.0
+      ts-api-utils: 2.0.1(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/parser@8.25.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.25.0
@@ -4628,6 +4839,18 @@ snapshots:
       debug: 4.4.0
       eslint: 9.21.0(jiti@2.4.2)
       typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.25.0(eslint@9.39.0(jiti@2.4.2))(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.25.0
+      '@typescript-eslint/types': 8.25.0
+      '@typescript-eslint/typescript-estree': 8.25.0(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.25.0
+      debug: 4.4.0
+      eslint: 9.39.0(jiti@2.4.2)
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
@@ -4647,6 +4870,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/type-utils@8.25.0(eslint@9.39.0(jiti@2.4.2))(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/typescript-estree': 8.25.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.25.0(eslint@9.39.0(jiti@2.4.2))(typescript@5.9.3)
+      debug: 4.4.0
+      eslint: 9.39.0(jiti@2.4.2)
+      ts-api-utils: 2.0.1(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/types@8.25.0': {}
 
   '@typescript-eslint/typescript-estree@8.25.0(typescript@5.7.3)':
@@ -4663,6 +4897,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/typescript-estree@8.25.0(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.25.0
+      '@typescript-eslint/visitor-keys': 8.25.0
+      debug: 4.4.0
+      fast-glob: 3.3.3
+      is-glob: 4.0.3
+      minimatch: 9.0.5
+      semver: 7.7.1
+      ts-api-utils: 2.0.1(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/utils@8.25.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.1(eslint@9.21.0(jiti@2.4.2))
@@ -4671,6 +4919,17 @@ snapshots:
       '@typescript-eslint/typescript-estree': 8.25.0(typescript@5.7.3)
       eslint: 9.21.0(jiti@2.4.2)
       typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.25.0(eslint@9.39.0(jiti@2.4.2))(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.1(eslint@9.39.0(jiti@2.4.2))
+      '@typescript-eslint/scope-manager': 8.25.0
+      '@typescript-eslint/types': 8.25.0
+      '@typescript-eslint/typescript-estree': 8.25.0(typescript@5.9.3)
+      eslint: 9.39.0(jiti@2.4.2)
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
@@ -4802,7 +5061,20 @@ snapshots:
     optionalDependencies:
       typescript: 5.7.3
 
-  '@vue/language-core@2.2.0(typescript@5.7.3)':
+  '@vue/language-core@2.1.6(typescript@5.9.3)':
+    dependencies:
+      '@volar/language-core': 2.4.11
+      '@vue/compiler-dom': 3.5.13
+      '@vue/compiler-vue2': 2.7.16
+      '@vue/shared': 3.5.13
+      computeds: 0.0.1
+      minimatch: 9.0.5
+      muggle-string: 0.4.1
+      path-browserify: 1.0.1
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@vue/language-core@2.2.0(typescript@5.9.3)':
     dependencies:
       '@volar/language-core': 2.4.11
       '@vue/compiler-dom': 3.5.13
@@ -4813,7 +5085,7 @@ snapshots:
       muggle-string: 0.4.1
       path-browserify: 1.0.1
     optionalDependencies:
-      typescript: 5.7.3
+      typescript: 5.9.3
 
   '@vue/shared@3.5.13': {}
 
@@ -4826,7 +5098,13 @@ snapshots:
     dependencies:
       acorn: 8.14.0
 
+  acorn-jsx@5.3.2(acorn@8.15.0):
+    dependencies:
+      acorn: 8.15.0
+
   acorn@8.14.0: {}
+
+  acorn@8.15.0: {}
 
   ajv-draft-04@1.0.0(ajv@8.13.0):
     optionalDependencies:
@@ -4858,17 +5136,6 @@ snapshots:
       uri-js: 4.4.1
 
   algorand-msgpack@1.1.0: {}
-
-  algosdk@3.2.0:
-    dependencies:
-      algorand-msgpack: 1.1.0
-      hi-base32: 0.5.1
-      js-sha256: 0.9.0
-      js-sha3: 0.8.0
-      js-sha512: 0.8.0
-      json-bigint: 1.0.0
-      tweetnacl: 1.0.3
-      vlq: 2.0.4
 
   algosdk@3.5.2:
     dependencies:
@@ -4988,7 +5255,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  bignumber.js@9.1.2: {}
+  bignumber.js@9.3.1: {}
 
   bn.js@4.12.1: {}
 
@@ -5294,6 +5561,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
   deep-eql@5.0.2: {}
 
   deep-is@0.1.4: {}
@@ -5547,6 +5818,11 @@ snapshots:
       eslint: 9.21.0(jiti@2.4.2)
       semver: 7.7.1
 
+  eslint-compat-utils@0.5.1(eslint@9.39.0(jiti@2.4.2)):
+    dependencies:
+      eslint: 9.39.0(jiti@2.4.2)
+      semver: 7.7.1
+
   eslint-config-prettier@10.0.1(eslint@9.21.0(jiti@2.4.2)):
     dependencies:
       eslint: 9.21.0(jiti@2.4.2)
@@ -5565,6 +5841,13 @@ snapshots:
       '@eslint-community/regexpp': 4.12.1
       eslint: 9.21.0(jiti@2.4.2)
       eslint-compat-utils: 0.5.1(eslint@9.21.0(jiti@2.4.2))
+
+  eslint-plugin-es-x@7.8.0(eslint@9.39.0(jiti@2.4.2)):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.1(eslint@9.39.0(jiti@2.4.2))
+      '@eslint-community/regexpp': 4.12.1
+      eslint: 9.39.0(jiti@2.4.2)
+      eslint-compat-utils: 0.5.1(eslint@9.39.0(jiti@2.4.2))
 
   eslint-plugin-import-x@4.6.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3):
     dependencies:
@@ -5586,12 +5869,44 @@ snapshots:
       - supports-color
       - typescript
 
+  eslint-plugin-import-x@4.6.1(eslint@9.39.0(jiti@2.4.2))(typescript@5.9.3):
+    dependencies:
+      '@types/doctrine': 0.0.9
+      '@typescript-eslint/scope-manager': 8.25.0
+      '@typescript-eslint/utils': 8.25.0(eslint@9.39.0(jiti@2.4.2))(typescript@5.9.3)
+      debug: 4.4.0
+      doctrine: 3.0.0
+      enhanced-resolve: 5.18.1
+      eslint: 9.39.0(jiti@2.4.2)
+      eslint-import-resolver-node: 0.3.9
+      get-tsconfig: 4.10.0
+      is-glob: 4.0.3
+      minimatch: 9.0.5
+      semver: 7.7.1
+      stable-hash: 0.0.4
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   eslint-plugin-n@17.15.1(eslint@9.21.0(jiti@2.4.2)):
     dependencies:
       '@eslint-community/eslint-utils': 4.4.1(eslint@9.21.0(jiti@2.4.2))
       enhanced-resolve: 5.18.1
       eslint: 9.21.0(jiti@2.4.2)
       eslint-plugin-es-x: 7.8.0(eslint@9.21.0(jiti@2.4.2))
+      get-tsconfig: 4.10.0
+      globals: 15.15.0
+      ignore: 5.3.2
+      minimatch: 9.0.5
+      semver: 7.7.1
+
+  eslint-plugin-n@17.15.1(eslint@9.39.0(jiti@2.4.2)):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.1(eslint@9.39.0(jiti@2.4.2))
+      enhanced-resolve: 5.18.1
+      eslint: 9.39.0(jiti@2.4.2)
+      eslint-plugin-es-x: 7.8.0(eslint@9.39.0(jiti@2.4.2))
       get-tsconfig: 4.10.0
       globals: 15.15.0
       ignore: 5.3.2
@@ -5667,9 +5982,16 @@ snapshots:
       esrecurse: 4.3.0
       estraverse: 5.3.0
 
+  eslint-scope@8.4.0:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
   eslint-visitor-keys@3.4.3: {}
 
   eslint-visitor-keys@4.2.0: {}
+
+  eslint-visitor-keys@4.2.1: {}
 
   eslint@9.21.0(jiti@2.4.2):
     dependencies:
@@ -5712,11 +6034,58 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint@9.39.0(jiti@2.4.2):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.0(jiti@2.4.2))
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.21.1
+      '@eslint/config-helpers': 0.4.2
+      '@eslint/core': 0.17.0
+      '@eslint/eslintrc': 3.3.1
+      '@eslint/js': 9.39.0
+      '@eslint/plugin-kit': 0.4.1
+      '@humanfs/node': 0.16.7
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.8
+      ajv: 6.12.6
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint-scope: 8.4.0
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      esquery: 1.6.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.2
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    optionalDependencies:
+      jiti: 2.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   espree@10.3.0:
     dependencies:
       acorn: 8.14.0
       acorn-jsx: 5.3.2(acorn@8.14.0)
       eslint-visitor-keys: 4.2.0
+
+  espree@10.4.0:
+    dependencies:
+      acorn: 8.15.0
+      acorn-jsx: 5.3.2(acorn@8.15.0)
+      eslint-visitor-keys: 4.2.1
 
   espree@9.6.1:
     dependencies:
@@ -6281,7 +6650,7 @@ snapshots:
 
   json-bigint@1.0.0:
     dependencies:
-      bignumber.js: 9.1.2
+      bignumber.js: 9.3.1
 
   json-buffer@3.0.1: {}
 
@@ -7228,9 +7597,17 @@ snapshots:
     dependencies:
       typescript: 5.7.3
 
+  ts-api-utils@2.0.1(typescript@5.9.3):
+    dependencies:
+      typescript: 5.9.3
+
   tsconfck@3.1.5(typescript@5.7.3):
     optionalDependencies:
       typescript: 5.7.3
+
+  tsconfck@3.1.5(typescript@5.9.3):
+    optionalDependencies:
+      typescript: 5.9.3
 
   tslib@2.8.1: {}
 
@@ -7304,6 +7681,15 @@ snapshots:
       typescript: 5.7.3
       yaml: 2.7.0
 
+  typedoc@0.27.9(typescript@5.9.3):
+    dependencies:
+      '@gerrit0/mini-shiki': 1.27.2
+      lunr: 2.3.9
+      markdown-it: 14.1.0
+      minimatch: 9.0.5
+      typescript: 5.9.3
+      yaml: 2.7.0
+
   typescript-eslint@8.25.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3):
     dependencies:
       '@typescript-eslint/eslint-plugin': 8.25.0(@typescript-eslint/parser@8.25.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
@@ -7314,9 +7700,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  typescript-eslint@8.25.0(eslint@9.39.0(jiti@2.4.2))(typescript@5.9.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.25.0(@typescript-eslint/parser@8.25.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.39.0(jiti@2.4.2))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.25.0(eslint@9.39.0(jiti@2.4.2))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.25.0(eslint@9.39.0(jiti@2.4.2))(typescript@5.9.3)
+      eslint: 9.39.0(jiti@2.4.2)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   typescript@5.4.2: {}
 
   typescript@5.7.3: {}
+
+  typescript@5.9.3: {}
 
   uc.micro@2.1.0: {}
 
@@ -7418,18 +7816,37 @@ snapshots:
       - rollup
       - supports-color
 
-  vite-plugin-dts@4.5.0(@types/node@22.13.9)(rollup@4.34.8)(typescript@5.7.3)(vite@6.2.0(@types/node@22.13.9)(jiti@2.4.2)(tsx@4.19.3)(yaml@2.7.0)):
+  vite-plugin-dts@4.2.3(@types/node@22.13.9)(rollup@4.34.8)(typescript@5.9.3)(vite@6.2.0(@types/node@22.13.9)(jiti@2.4.2)(tsx@4.19.3)(yaml@2.7.0)):
     dependencies:
-      '@microsoft/api-extractor': 7.51.0(@types/node@22.13.9)
+      '@microsoft/api-extractor': 7.47.7(@types/node@22.13.9)
       '@rollup/pluginutils': 5.1.4(rollup@4.34.8)
       '@volar/typescript': 2.4.11
-      '@vue/language-core': 2.2.0(typescript@5.7.3)
+      '@vue/language-core': 2.1.6(typescript@5.9.3)
       compare-versions: 6.1.1
       debug: 4.4.0
       kolorist: 1.8.0
       local-pkg: 0.5.1
       magic-string: 0.30.17
-      typescript: 5.7.3
+      typescript: 5.9.3
+    optionalDependencies:
+      vite: 6.2.0(@types/node@22.13.9)(jiti@2.4.2)(tsx@4.19.3)(yaml@2.7.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - rollup
+      - supports-color
+
+  vite-plugin-dts@4.5.0(@types/node@22.13.9)(rollup@4.34.8)(typescript@5.9.3)(vite@6.2.0(@types/node@22.13.9)(jiti@2.4.2)(tsx@4.19.3)(yaml@2.7.0)):
+    dependencies:
+      '@microsoft/api-extractor': 7.51.0(@types/node@22.13.9)
+      '@rollup/pluginutils': 5.1.4(rollup@4.34.8)
+      '@volar/typescript': 2.4.11
+      '@vue/language-core': 2.2.0(typescript@5.9.3)
+      compare-versions: 6.1.1
+      debug: 4.4.0
+      kolorist: 1.8.0
+      local-pkg: 0.5.1
+      magic-string: 0.30.17
+      typescript: 5.9.3
     optionalDependencies:
       vite: 6.2.0(@types/node@22.13.9)(jiti@2.4.2)(tsx@4.19.3)(yaml@2.7.0)
     transitivePeerDependencies:
@@ -7454,6 +7871,17 @@ snapshots:
       debug: 4.4.0
       globrex: 0.1.2
       tsconfck: 3.1.5(typescript@5.7.3)
+    optionalDependencies:
+      vite: 6.2.0(@types/node@22.13.9)(jiti@2.4.2)(tsx@4.19.3)(yaml@2.7.0)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  vite-tsconfig-paths@5.1.4(typescript@5.9.3)(vite@6.2.0(@types/node@22.13.9)(jiti@2.4.2)(tsx@4.19.3)(yaml@2.7.0)):
+    dependencies:
+      debug: 4.4.0
+      globrex: 0.1.2
+      tsconfck: 3.1.5(typescript@5.9.3)
     optionalDependencies:
       vite: 6.2.0(@types/node@22.13.9)(jiti@2.4.2)(tsx@4.19.3)(yaml@2.7.0)
     transitivePeerDependencies:
@@ -7530,6 +7958,19 @@ snapshots:
     dependencies:
       debug: 4.4.0
       eslint: 9.21.0(jiti@2.4.2)
+      eslint-scope: 7.2.2
+      eslint-visitor-keys: 3.4.3
+      espree: 9.6.1
+      esquery: 1.6.0
+      lodash: 4.17.21
+      semver: 7.7.1
+    transitivePeerDependencies:
+      - supports-color
+
+  vue-eslint-parser@9.4.3(eslint@9.39.0(jiti@2.4.2)):
+    dependencies:
+      debug: 4.4.0
+      eslint: 9.39.0(jiti@2.4.2)
       eslint-scope: 7.2.2
       eslint-visitor-keys: 3.4.3
       espree: 9.6.1


### PR DESCRIPTION
## Summary

This PR makes `algosdk` a peer dependency, requiring users to install it separately. This change enables better version flexibility and reduces bundle size for consumers who may already have `algosdk` installed.

## Changes

- **Package Configuration**
  - Moved `algosdk` from `dependencies` to `peerDependencies` with version `^3.0.0`
  - Added `algosdk@^3.5.2` as a dev dependency for development and testing
- **Documentation**
  - Updated installation instructions in root README to include `algosdk`
  - Updated installation instructions in SDK README to include `algosdk`
  - Removed versioning section from SDK README (breaking changes now follow semver)
- **Examples**
  - Added `algosdk@^3.5.2` to all example projects
  - Updated existing `algosdk` versions in examples to `^3.5.2`

## Breaking Change

`algosdk` is now a peer dependency and must be installed separately:

```bash
# Before
npm install @txnlab/nfd-sdk

# After
npm install @txnlab/nfd-sdk algosdk
```

Users must ensure they have `algosdk ^3.0.0` installed alongside `@txnlab/nfd-sdk`.

## Test Plan

- [x] Verify SDK builds successfully with algosdk as peer dependency
- [x] Verify all example projects have algosdk installed
- [x] Verify CI/PR workflows pass
