### PR TITLE
ci: bump GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Pull Request
+name: CI
 
 on:
   pull_request:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,6 +23,10 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version-file: '.nvmrc'
+          # pnpm is installed in a later step; this workflow caches the pnpm
+          # store manually below, so disable setup-node's auto cache (default
+          # changed to true in v5 and runs before pnpm is on PATH).
+          package-manager-cache: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,17 +15,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version-file: '.nvmrc'
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           run_install: false
 
@@ -36,7 +36,7 @@ jobs:
           echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - name: Setup pnpm cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,23 +19,23 @@ jobs:
     steps:
       - name: Generate release token
         id: generate_token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           persist-credentials: false
           token: ${{ steps.generate_token.outputs.token }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
## Summary

Addresses the GitHub deprecation of Node 20-based actions (forced to Node 24 on 2026-06-02, removed 2026-09-16). Verified each target version runs on `node24` via its `action.yml`.

| Action | Before | After |
| --- | --- | --- |
| actions/checkout | v4 | v5 |
| actions/setup-node | v4 | v5 |
| actions/create-github-app-token | v2 | v3 |
| pnpm/action-setup | v4 | v6 |
| actions/cache | v4 | v5 |

No behavioral change expected: `pnpm/action-setup@v6` still auto-detects the version from the pinned `packageManager`, and the app-token inputs are unchanged.

This is a `ci:` change, so merging it will run the `Release` job and exit with "no new version is released".

## Test plan
- [ ] PR check (`Lint, Test, and Build`) passes on the bumped runners
- [ ] After merge, the `Release` run completes cleanly with no deprecation annotation and publishes nothing